### PR TITLE
Handle alternate line endings

### DIFF
--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -47,7 +47,7 @@ describe('runner', () => {
       setup: 'javac Hello.java',
       run: 'java -cp . Hello',
       input: 'Jeff',
-      output: 'What is your name?\r\nHello Jeff\n\r\n',
+      output: 'What is your name?\nHello Jeff\n\n',
       comparison: 'exact' as TestComparison,
       timeout: 5000,
     }


### PR DESCRIPTION
To handle the differences between different platforms (Windows, Linux and Mac for example) we want to normalize the line endings for comparison. The trade-off here is that it becomes very difficult to do exact matching if the assignment were about normalizing line ends (for instance). In that case input/output tests might not be the right tool.