### PR TITLE
Trim leading and trailing spaces from output

### DIFF
--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -19,7 +19,7 @@ describe('runner', () => {
       input: 'Jeff',
       output: 'Hello Jeff',
       comparison: 'included' as TestComparison,
-      timeout: 5000,
+      timeout: 1,
     }
 
     await expect(run(test, cwd)).resolves.not.toThrow()
@@ -34,7 +34,7 @@ describe('runner', () => {
       input: 'Jeff',
       output: 'Jeff',
       comparison: 'regex' as TestComparison,
-      timeout: 5000,
+      timeout: 1,
     }
 
     await expect(run(test, cwd)).resolves.not.toThrow()
@@ -49,7 +49,7 @@ describe('runner', () => {
       input: 'Jeff',
       output: 'What is your name?\nHello Jeff\n\n',
       comparison: 'exact' as TestComparison,
-      timeout: 5000,
+      timeout: 1,
     }
 
     await expect(run(test, cwd)).resolves.not.toThrow()
@@ -64,9 +64,24 @@ describe('runner', () => {
       input: 'Jeff',
       output: 'Hello Mike',
       comparison: 'included' as TestComparison,
-      timeout: 5000,
+      timeout: 1,
     }
 
     await expect(run(test, cwd)).rejects.toThrow('The output for test Hello Test did not match')
+  }, 10000)
+
+  it('can read shell output', async () => {
+    const cwd = path.resolve(__dirname, 'shell')
+    const test = {
+      name: 'Hello Test',
+      setup: '',
+      run: 'sh hello.sh',
+      input: 'Nathaniel',
+      output: 'Hello Nathaniel',
+      comparison: 'exact' as TestComparison,
+      timeout: 1,
+    }
+
+    await expect(run(test, cwd)).resolves.not.toThrow()
   }, 10000)
 })

--- a/src/__tests__/shell/hello.sh
+++ b/src/__tests__/shell/hello.sh
@@ -1,0 +1,1 @@
+echo "Hello Nathaniel"

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -42,7 +42,7 @@ export class TestOutputError extends TestError {
 }
 
 const normalizeLineEndings = (text: string): string => {
-  return text.replace(/\r\n/gi, '\n')
+  return text.replace(/\r\n/gi, '\n').trim()
 }
 
 const waitForExit = async (child: ChildProcess, timeout: number): Promise<void> => {


### PR DESCRIPTION
Because we end up with a final newline in specific cases we want to trim leading and trailing empty characters. Similar to #4, this might mean that input/output exact matching doesn't work in every case (for example, if you are trying to test extra spaces at the end of output). The tradeoff is that it handles a wider variety of default cases.