### PR TITLE
Handle empty input and output

### DIFF
--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -84,4 +84,19 @@ describe('runner', () => {
 
     await expect(run(test, cwd)).resolves.not.toThrow()
   }, 10000)
+
+  it('does not compare when there is no expected input and no expected output', async () => {
+    const cwd = path.resolve(__dirname, 'shell')
+    const test = {
+      name: 'Hello Test',
+      setup: '',
+      run: 'sh hello.sh',
+      input: undefined,
+      output: undefined,
+      comparison: 'exact' as TestComparison,
+      timeout: 1,
+    }
+
+    await expect(run(test, cwd)).resolves.not.toThrow()
+  }, 10000)
 })

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -8,8 +8,8 @@ export interface Test {
   readonly name: string
   readonly setup: string
   readonly run: string
-  readonly input: string
-  readonly output: string
+  readonly input?: string
+  readonly output?: string
   readonly timeout: number
   readonly comparison: TestComparison
 }
@@ -120,7 +120,12 @@ const runCommand = async (test: Test, cwd: string, timeout: number): Promise<voi
 
   await waitForExit(child, timeout)
 
-  const expected = normalizeLineEndings(test.output)
+  // Eventually work off the the test type
+  if ((!test.output || test.output == '') && (!test.input || test.input == '')) {
+    return
+  }
+
+  const expected = normalizeLineEndings(test.output || '')
   const actual = normalizeLineEndings(output)
 
   switch (test.comparison) {
@@ -131,8 +136,8 @@ const runCommand = async (test: Test, cwd: string, timeout: number): Promise<voi
       break
     case 'regex':
       // Note: do not use expected here
-      if (!actual.match(new RegExp(test.output))) {
-        throw new TestOutputError(`The output for test ${test.name} did not match`, test.output, actual)
+      if (!actual.match(new RegExp(test.output || ''))) {
+        throw new TestOutputError(`The output for test ${test.name} did not match`, test.output || '', actual)
       }
       break
     default:


### PR DESCRIPTION
Currently we compare output even when there is no intended comparison. This handles empty input and output. The one case where this does not work is if you have no input and are explicitly expecting empty output. Eventually we can trigger this based on the test type.