### PR TITLE
Null points

### DIFF
--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -193,4 +193,25 @@ describe('runAll', () => {
     await expect(runAll(tests, cwd)).resolves.not.toThrow()
     expect(setOutputSpy).toHaveBeenCalledWith('Points', '7/7')
   }, 10000)
+
+  it('gets 0 points if it fails', async () => {
+    const cwd = path.resolve(__dirname, 'shell')
+    const tests = [
+      {
+        name: 'Hello Test',
+        setup: '',
+        run: 'exit 1',
+        input: undefined,
+        output: undefined,
+        comparison: 'exact' as TestComparison,
+        timeout: 1,
+        points: 7,
+      },
+    ]
+
+    // Expect the points to be in the output
+    const setOutputSpy = jest.spyOn(core, 'setOutput')
+    await expect(runAll(tests, cwd)).resolves.not.toThrow()
+    expect(setOutputSpy).toHaveBeenCalledWith('Points', '0/7')
+  }, 10000)
 })

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -168,8 +168,9 @@ export const run = async (test: Test, cwd: string): Promise<void> => {
 }
 
 export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => {
-  let points = null
-  let totalPoints = null
+  let points = 0
+  let availablePoints = 0
+  let hasPoints = false
 
   // https://help.github.com/en/actions/reference/development-tools-for-github-actions#stop-and-start-log-commands-stop-commands
   const token = uuidv4()
@@ -179,14 +180,13 @@ export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => 
   for (const test of tests) {
     try {
       if (test.points) {
-        totalPoints = totalPoints || 0
-        totalPoints += test.points
+        hasPoints = true
+        availablePoints += test.points
       }
       console.log(`Running ${test.name}`)
       await run(test, cwd)
       console.log(`${test.name} Passed`)
       if (test.points) {
-        points = points || 0
         points += test.points
       }
     } catch (error) {
@@ -198,10 +198,10 @@ export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => 
   console.log(`::${token}::`)
 
   // Set the number of points
-  if (totalPoints) {
-    const text = `Points ${points}/${totalPoints}`
+  if (hasPoints) {
+    const text = `Points ${points}/${availablePoints}`
     console.log(text)
-    core.setOutput('Points', `${points}/${totalPoints}`)
+    core.setOutput('Points', `${points}/${availablePoints}`)
     await setCheckRunOutput(text)
   }
 }


### PR DESCRIPTION
Based on #9 (blocked until that lands)

Previously, if it were possible to score points and all of the tests failed you would see:

`Points null/10`

This fixes that and correctly tallies 0 points achieved.