### PR TITLE
Pass the path to the env

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -87,7 +87,9 @@ const runSetup = async (test: Test, cwd: string, timeout: number): Promise<void>
   const setup = spawn(test.setup, {
     cwd,
     shell: true,
-    env: {},
+    env: {
+      PATH: process.env['PATH'],
+    },
   })
 
   setup.stdout.on('data', chunk => {
@@ -105,7 +107,9 @@ const runCommand = async (test: Test, cwd: string, timeout: number): Promise<voi
   const child = spawn(test.run, {
     cwd,
     shell: true,
-    env: {},
+    env: {
+      PATH: process.env['PATH'],
+    },
   })
 
   let output = ''


### PR DESCRIPTION
For security reasons we are clearing the `env` that is passed to the subprocesses. Unfortunately we need to have access to the `PATH` in the subprocesses. So we pass this in.