### PR TITLE
Adds ability to mark some tests as "extra" - Issue #29

### DIFF
--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -200,6 +200,49 @@ describe('runAll', () => {
     expect(setOutputSpy).toHaveBeenCalledWith('Points', '7/7')
   }, 10000)
 
+  it('counts extra credit points', async () => {
+    const cwd = path.resolve(__dirname, 'shell')
+    const tests = [
+      {
+        name: 'Regular credit Test',
+        setup: '',
+        run: 'sh hello.sh',
+        input: undefined,
+        output: undefined,
+        comparison: 'exact' as TestComparison,
+        timeout: 1,
+        points: 7,
+      },
+      {
+        name: 'Extra credit Test',
+        setup: '',
+        run: 'sh hello.sh',
+        input: undefined,
+        output: undefined,
+        comparison: 'exact' as TestComparison,
+        timeout: 1,
+		extra: true,
+        points: 3,
+      },
+      {
+        name: 'Failing extra credit Test',
+        setup: '',
+        run: 'sh hello.sh',
+        input: undefined,
+        output: 'Fail this test',
+        comparison: 'exact' as TestComparison,
+        timeout: 1,
+		extra: true,
+        points: 5,
+      },
+    ]
+
+    // Expect the points to be in the output
+    const setOutputSpy = jest.spyOn(core, 'setOutput')
+    await expect(runAll(tests, cwd)).resolves.not.toThrow()
+    expect(setOutputSpy).toHaveBeenCalledWith('Points', '10/7')
+  }, 10000)
+
   it('gets 0 points if it fails', async () => {
     const cwd = path.resolve(__dirname, 'shell')
     const tests = [

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -18,6 +18,7 @@ export interface Test {
   readonly output?: string
   readonly timeout: number
   readonly points?: number
+  readonly extra?: boolean
   readonly comparison: TestComparison
 }
 
@@ -213,7 +214,9 @@ export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => 
     try {
       if (test.points) {
         hasPoints = true
-        availablePoints += test.points
+        if (!test.extra) {
+          availablePoints += test.points
+        }
       }
       log(color.cyan(`📝 ${test.name}`))
       log('')
@@ -225,7 +228,9 @@ export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => 
         points += test.points
       }
     } catch (error) {
-      failed = true
+      if (!test.extra) {
+        failed = true
+      }
       log('')
       log(color.red(`❌ ${test.name}`))
       core.setFailed(error.message)
@@ -243,6 +248,12 @@ export const runAll = async (tests: Array<Test>, cwd: string): Promise<void> => 
     log(color.green('All tests passed'))
     log('')
     log('✨🌟💖💎🦄💎💖🌟✨🌟💖💎🦄💎💖🌟✨')
+    log('')
+  }
+
+  if (points > availablePoints) {
+    const extraCreditPoints = points - availablePoints
+    log(`💪💪💪 You earned ${extraCreditPoints} extra credit points`)
     log('')
   }
 


### PR DESCRIPTION
- Setting a test's "extra" attribute to `true` keeps its points from
  being added to the points possible tally
- Failures of extra credit tests do not result in a "failure" display