### PR TITLE
Allow more env for spawn

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -102,10 +102,6 @@ const runSetup = async (test: Test, cwd: string, timeout: number): Promise<void>
   const setup = spawn(test.setup, {
     cwd,
     shell: true,
-    env: {
-      PATH: process.env['PATH'],
-      FORCE_COLOR: 'true',
-    },
   })
 
   // Start with a single new line
@@ -128,10 +124,6 @@ const runCommand = async (test: Test, cwd: string, timeout: number): Promise<voi
   const child = spawn(test.run, {
     cwd,
     shell: true,
-    env: {
-      PATH: process.env['PATH'],
-      FORCE_COLOR: 'true',
-    },
   })
 
   let output = ''


### PR DESCRIPTION
Currently when child processes are spawned, access to environment variables is very limited. This results in a number of languages being unable to run. Notably: 

- #23 
- [dotnet](https://education.github.community/t/dotnet-auto-grading/72717)

Proposed fix: use default process.env for spawn. This will give the spawned process access to all environement variables on the runner, including the variables needed by Golang and dotnet. (e.g. DOTNET_CLI_HOME fallback.)