### PR TITLE
Ignore chalk v5 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "chalk"
+        update-types: ["version-update:semver-major"]    


### PR DESCRIPTION
[Chalk v5](https://github.com/chalk/chalk#install) changes to ESM. It's probably easier to leave chalk at version 4 for now.

This PR updates dependabot config to ignore chalk major version updates.