### PR TITLE
Replace Empty String with Expected Output String in CI Test

### DIFF
--- a/.github/classroom/autograding.json
+++ b/.github/classroom/autograding.json
@@ -5,7 +5,7 @@
       "setup": "",
       "run": "echo 'Test 1'",
       "input": "",
-      "output": "",
+      "output": "Test 1",
       "comparison": "included",
       "timeout": 10,
       "points": 5


### PR DESCRIPTION
While looking through how tests work inside this repo @octosteve and I noticed that the `autograding.json` file expects an output of an empty string even though it is outputting 'Test 1'. 

This change updates the `output` field in `.github/classroom/autograding.json` to ensure the autograder tests the code's functionality.

* `.github/classroom/autograding.json`: Updated the `output` field to "Test 1" in `.github/classroom/autograding.json` 