### PR TITLE
Fix lint error in spawn env object

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -107,7 +107,7 @@ const runSetup = async (test: Test, cwd: string, timeout: number): Promise<void>
       FORCE_COLOR: 'true',
       DOTNET_CLI_HOME: '/tmp',
       DOTNET_NOLOGO: 'true',
-      HOME: process.env['HOME']
+      HOME: process.env['HOME'],
     },
   })
 
@@ -136,7 +136,7 @@ const runCommand = async (test: Test, cwd: string, timeout: number): Promise<voi
       FORCE_COLOR: 'true',
       DOTNET_CLI_HOME: '/tmp',
       DOTNET_NOLOGO: 'true',
-      HOME: process.env['HOME']
+      HOME: process.env['HOME'],
     },
   })
 


### PR DESCRIPTION
Fix for lint error at the end of the env object used by spawn.

@zrdaley There's a lint error in the recently merged PR #53 . This should fix it. (See failed unit tests: https://github.com/education/autograding/actions/runs/6224677258)
