### PR TITLE
Add direct points input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,11 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      # run the action from the local path
       - uses: ./
+
+      # run the local action with point inputs
+      - uses: ./
+        with:
+          points: 10
+          available-points: 20

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,14 @@ inputs:
       by replacing this token with a user token which has write-access to your repository. 
       Note that the token will be accessible to all repository collaborators.
     default: ${{ github.token }}
+  points:
+    description: >
+      The number of points scored for this assignment. Must be an integer.
+    required: false
+  available-points:
+    description: >
+      The total number of points available for this assignment. Must be an integer.
+    required: false
 runs:
   using: "node16"
   main: "./dist/index.js"

--- a/src/autograding.ts
+++ b/src/autograding.ts
@@ -12,6 +12,7 @@ const run = async (): Promise<void> => {
 
     // if points inputs are present, set the output and call checkRun
     if (points && availablePoints) {
+      core.info(`Using direct input points.`)
       const text = `Points ${points}/${availablePoints}`
       core.setOutput('Points', `${points}/${availablePoints}`)
       await setCheckRunOutput(text)

--- a/src/autograding.ts
+++ b/src/autograding.ts
@@ -2,9 +2,23 @@ import * as core from '@actions/core'
 import fs from 'fs'
 import path from 'path'
 import {Test, runAll} from './runner'
+import {setCheckRunOutput} from './output'
 
 const run = async (): Promise<void> => {
   try {
+    // try to get points inputs
+    const points = core.getInput('points')
+    const availablePoints = core.getInput('available-points')
+
+    // if points inputs are present, set the output and call checkRun
+    if (points && availablePoints) {
+      const text = `Points ${points}/${availablePoints}`
+      core.setOutput('Points', `${points}/${availablePoints}`)
+      await setCheckRunOutput(text)
+      return
+    }
+
+    // Otherwise, try to run the tests
     const cwd = process.env['GITHUB_WORKSPACE']
     if (!cwd) {
       throw new Error('No GITHUB_WORKSPACE')


### PR DESCRIPTION
Add action inputs for `points` and `availablePoints` that bypasses grading tests and goes direct to check run to report grading score back to the GH Classroom interface.

There are use-cases where doing grading tests and calculating final score is easier to do outside of `autograding`. By providing points inputs, these workflows can be supported without having to maintain 2 separate equivalents of [`setCheckRunOutput`](https://github.com/education/autograding/blob/272ad69b696346bf702a8423feb1d8d9f092bcab/src/output.ts#L4).

See:
- #52 
- https://github.com/orgs/community/discussions/77361#discussioncomment-7720245

#### Usage
Inputs are optional. Without both `points` and `available-points` being provided, `autograding` will run grading tests as normal. If both inputs are provided, `autograding` tests are skipped and [`setCheckRunOutput`](https://github.com/education/autograding/blob/272ad69b696346bf702a8423feb1d8d9f092bcab/src/output.ts#L4) is run with the provided inputs.

Example usage:

```yaml
...
      - name: run grading
        id: grading
        run: |
          <command to run unit tests with grading output>
          echo "points=$calc_points" >> $GITHUB_OUTPUT
          echo "total-points=$calc_total_points" >> $GITHUB_OUTPUT

      - uses: education/autograding@master
        with:
          points: ${{ steps.grading.outputs.points }}
          available-points: ${{ steps.grading.outputs.total-points }}
```

If anyone wants to try it out, I have a build on my fork on the [dev-points-input-release](https://github.com/markpatterson27/autograding/tree/dev-points-input-release) branch (replace `education/autograding@master` with `markpatterson27/autograding@dev-points-input-release`)

#### ToDo
- [ ] add jest tests